### PR TITLE
Add initial support for Markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nan1-ssg
 
-nan1-ssg is a static site generator converting .txt files to .html files.
+nan1-ssg is a static site generator converting .txt and .md files to .html files.
 
 ## Requirements
 
@@ -38,13 +38,18 @@ nan1-ssg [-option]
 | -h, --help | Will display a help message, showing options and usage. |
 | -i <filename>, --input <filename> | Gives the tool a filename to generate HTML files with. The filename can be a file or a directory. |
 
-The hello.txt file and Sherlock-Holmes-Selected-Stories directory is provided for testing purposes.
+The hello.txt file, markdownTest.md file,  and Sherlock-Holmes-Selected-Stories directory are provided for testing purposes.
 
 ## Examples
 
 **For a text file:**
 ```
 nan1-ssg -i hello.txt
+```
+
+**For a markdown file:**
+```
+nan1-ssg -i hello.md
 ```
 
 **For a directory:**
@@ -64,6 +69,6 @@ nan1-ssg -i "file with spaces.txt"
 
 ## Features
 
-- Generating valid HTML5 files from .txt files and placed in the dist directory
+- Generating valid HTML5 files from .txt and .md files and placed in the dist directory
 - An index.html file is created which contain relative links to the generated HTML files
 - Each HTML file uses a default stylesheet to improve beauty and readability

--- a/generateHTML.js
+++ b/generateHTML.js
@@ -125,14 +125,17 @@ function readMdFile(input)
             {
                 // regex to find opening and closing '**' in the line
                 //  based off of stackoverflow answer found here: https://stackoverflow.com/a/2295943 
+
+                // the pattern below matches multiple sets of characters that are surrounded by '**'
                 let pattern = /\*\*(?:\\.|[^\*\*])*\*\*/gm;
                 let matchIndexes = [];
                 let match;
+
+                // the while loop below will test the regex pattern against the line, and then push the beginning and ending index of the match into the match indexes array to find the positions where to place the <strong>...</strong> tags
                 while( match = pattern.exec(theLine) ){
                     matchIndexes.push(match.index);
                     matchIndexes.push(pattern.lastIndex);
                 }
-                console.log(matchIndexes);
 
                 // // make a modifiable copy of theLine
                 let modifiedLine = theLine;

--- a/main.js
+++ b/main.js
@@ -11,7 +11,7 @@ program.parse(process.argv);
 if (program.opts().version)
 {
     console.log("name: nan1-ssg");
-    console.log("version: 0.1");
+    console.log("version: 0.2");
 }
 
 if (program.opts().input)

--- a/markdownTest.md
+++ b/markdownTest.md
@@ -1,0 +1,7 @@
+this line has no bolded text
+this line has **bolded** text.
+
+this **line** has **alternating** bolded **text**.
+
+**this entire line should be bolded**. 
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nan1-ssg",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nan1-ssg",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
         "commander": "^9.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nan1-ssg",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Release 0.1 of nan1-ssg",
   "main": "nan1-ssg.js",
   "scripts": {


### PR DESCRIPTION
This code resolves [issue 6](https://github.com/NeilAn99/nan1-ssg/issues/6). 

Users now have the ability to parse markdown files to generate an html file, as well as parsing through each line of the markdown file to find pieces of text that are meant to be builded (with the "**" symbols).

This was accomplished by modifying generateHTML.js, and adding a new function called readMdFile. I also changed readFile to readTextFile to differentiate between the two. 

Also, I added /dist folder to .gitignore to prevent uploading the generated test websties to git.

I also modified main.js to represent a version bump. 

