### PR TITLE
Add support for JSON formatted Config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ nan1-ssg [-option]
 | -h, --help | Will display a help message, showing options and usage. |
 | -i <filename>, --input <filename> | Gives the tool a filename to generate HTML files with. The filename can be a file or a directory. |
 | -l <language>, --lang <language> | Specifies a language to generate the HTML from. |
+| -c <configFile>, --config <configFile> | Add a JSON config file to specify options. Omit other options when using this option. |
 
-The hello.txt file, markdownTest.md file,  and Sherlock-Holmes-Selected-Stories directory are provided for testing purposes.
+The hello.txt file, markdownTest.md file, ssg-config.json file and Sherlock-Holmes-Selected-Stories directory are provided for testing purposes.
 
 ## Examples
 
@@ -73,6 +74,11 @@ nan1-ssg -i "./Sherlock-Holmes-Selected-Stories/Silver Blaze.txt"
 nan1-ssg -i "file with spaces.txt"
 ```
 
+**Using a configuration JSON file:**
+```
+nan1-ssg -c ./ssg-config.json
+```
+
 ## Features
 
 - Generating valid HTML5 files from .txt and .md files and placed in the dist directory
@@ -80,3 +86,11 @@ nan1-ssg -i "file with spaces.txt"
 - Each HTML file uses a default stylesheet to improve beauty and readability
 - Can specify language to HTML file to use
 - Horizontal rules are translated from Markdown files
+- A configuration JSON file can be used to specify all options
+    - Example file format:
+    ```json
+    {
+        "input": "./ssg-config.json",
+        "lang": "fr"
+    }
+    ```

--- a/main.js
+++ b/main.js
@@ -5,7 +5,8 @@ import { program } from 'commander';
 program
 .option('-v, --version', 'displays the tool name and version')
 .option('-i, --input <item>', 'gets input from a file or folder')
-.option('-l, --lang <item>', 'specifies language to use');
+.option('-l, --lang <item>', 'specifies language to use')
+.option('-c, --config <item>', 'Add a JSON config file to specify options');
 
 program.parse(process.argv);
 
@@ -15,6 +16,10 @@ if (program.opts().version)
     console.log("version: 0.2");
 }
 
+if(program.opts().config)
+{
+    
+}
 if (program.opts().input)
 {
     if (program.opts().lang)

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 #! /usr/bin/env node
 import { generateHTML } from './generateHTML.js';
 import { program } from 'commander';
+import fs, { read } from 'fs';
 
 program
 .option('-v, --version', 'displays the tool name and version')
@@ -18,7 +19,13 @@ if (program.opts().version)
 
 if(program.opts().config)
 {
-    
+    readConfigFile(program.opts().config).then(function(configFile)
+    {
+        generateHTML(configFile.input, configFile.lang);
+    }).catch(function (rej)
+    {
+        console.log(rej)
+    })
 }
 if (program.opts().input)
 {
@@ -33,3 +40,20 @@ if (program.opts().input)
     }
 }
 
+//this function will read a JSON config file
+function readConfigFile(config)
+{
+    return new Promise(function(res, rej)
+    {
+        if(fs.existsSync(config))
+        {
+            const theFile = fs.readFileSync(config, "utf-8");
+            const JSONfile = JSON.parse(theFile);
+            res(JSONfile);    
+        }
+        else
+        {
+            rej("Error: Config file does not exist.")
+        }
+    })
+}

--- a/main.js
+++ b/main.js
@@ -22,9 +22,10 @@ if(program.opts().config)
     readConfigFile(program.opts().config).then(function(configFile)
     {
         generateHTML(configFile.input, configFile.lang);
-    }).catch(function (rej)
+    })
+    .catch(function (rej)
     {
-        console.log(rej)
+        console.log(rej);
     })
 }
 if (program.opts().input)
@@ -53,7 +54,7 @@ function readConfigFile(config)
         }
         else
         {
-            rej("Error: Config file does not exist.")
+            rej("Error: Config file does not exist.");
         }
     })
 }

--- a/ssg-config.json
+++ b/ssg-config.json
@@ -1,0 +1,5 @@
+{
+    "input": "Sherlock-Holmes-Selected-Stories",
+    "output": "./build",
+    "stylesheet": "https://cdn.jsdelivr.net/npm/water.css@2/out/water.css"
+}


### PR DESCRIPTION
# Overview
This pull request is intended to resolve #13.  
  
Users will be able to pass in a JSON formatted configuration file as an option. This `config` file can contain any number of the options that this tool supports. Therefore, the user would not need to specify all options individually as command line arguments

## Features
- Added ability to read from a config JSON file containing all required options.

## Code Changes
- Added additional option in `main.js line: 10` to accept `-c`/`--config` arguments.
- Created a new function (`readConfigFile`)  in `main.js line: 45`  to read and parse JSON files.
- Added a conditional statement that will call `readConfigFile` if a config file is specified in the command line. Each option in the file will be passed into `generateHTML`